### PR TITLE
Allow menuItem to be created even if createdBy is null

### DIFF
--- a/Scouter/Scouter/FreeScoutAPI/Models/ConversationContainer.swift
+++ b/Scouter/Scouter/FreeScoutAPI/Models/ConversationContainer.swift
@@ -39,7 +39,7 @@ struct ConversationPreview: Codable {
     let preview: String
     let mailboxID: String?
     let assignee: User?
-    let createdBy: User
+    let createdBy: User?
     let createdAt: String
     let updatedAt: String
     let closedBy: Int?

--- a/Scouter/Scouter/MenuManager.swift
+++ b/Scouter/Scouter/MenuManager.swift
@@ -90,7 +90,9 @@ class MenuManager {
         )
         menuItem.target = self
         menuItem.indentationLevel = 1
-        menuItem.badge = NSMenuItemBadge(string: conversation.createdBy.name().truncated(18))
+        if (conversation.createdBy != nil) {
+            menuItem.badge = NSMenuItemBadge(string: conversation.createdBy!.name().truncated(18))
+        }
         menuItem.tag = conversation.id
         menuItem.toolTip = toolTipFor(conversation)
 


### PR DESCRIPTION
conversation.createdBy can be null.  This causes a Serialization Failed error to occur and no menu is built.  This patches the menu builder so the item can still be referenced.